### PR TITLE
fix error with full_info and POT

### DIFF
--- a/R/internals.R
+++ b/R/internals.R
@@ -96,12 +96,18 @@ get_ts_internal <- function(id, type, metadata, verbose, full_info) {
       if (type %in% c("pot-stage", "pot-flow")){
         rejected_periods <- unlist(station_info$`peak-flow-rejected-periods`,
                                    use.names = FALSE)
-        periods <- lapply(X = strsplit(rejected_periods, "[/]"), FUN = as.Date)
-        periods <- lapply(X = periods,
-                          FUN = function(x) {
-                            seq.Date(from = x[1], to = x[2], by = "day")
-                          })
-        periods <- do.call("c", periods)
+        
+        periods <- vector(mode="numeric",length=0)
+        periods <- as.Date(periods,  origin="1970-01-01")
+        ### only do this when there are missing periods 
+        if(!is.null(rejected_periods)){
+          periods <- lapply(X = strsplit(rejected_periods, "[/]"), FUN = as.Date)
+          periods <- lapply(X = periods,
+                            FUN = function(x) {
+                              seq.Date(from = x[1], to = x[2], by = "day")
+                            })
+          periods <- do.call("c", periods)
+        }
         df$rejected <- ifelse(test = as.Date(datatime) %in% periods,
                               yes = TRUE, no = FALSE)
       }
@@ -114,7 +120,7 @@ get_ts_internal <- function(id, type, metadata, verbose, full_info) {
                               yes = TRUE, no = FALSE)
       }
     }
-    df <- zoo::zoo(x = df, order.by = as.Date(datatime), )
+    df <- zoo::zoo(x = df, order.by = as.Date(datatime))
   }
 
   if (metadata) {

--- a/tests/testthat/test-get_ts.R
+++ b/tests/testthat/test-get_ts.R
@@ -73,5 +73,9 @@ test_that("Check get_ts works with other types", {
                structure(c(1L, 10L), .Dim = 2L,
                          .Dimnames = structure(list(c("0", "1")), .Names = ""),
                          class = "table"))
-
+  x3 <- get_ts(id = 72014, type = "pot-flow", full_info = TRUE)
+  expect_equal(table(x3$rejected[1:176]),
+               structure(c(`0` = 176L), .Dim = 1L, 
+                         .Dimnames = structure(list("0"), .Names = ""), 
+                         class = "table"))
 })


### PR DESCRIPTION
When asking full_info =TRUE on POT with no missing/non-valid records I got Error in strsplit(rejected_periods, "[/]") : non-character argument. Fixed by creating an empty periods vector. Also added a test for that